### PR TITLE
アプリ側でidを採番する

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -14,6 +14,7 @@ require (
 )
 
 require (
+	github.com/bwmarrin/snowflake v0.3.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
 	github.com/felixge/fgprof v0.9.4 // indirect
 	github.com/goccy/go-json v0.9.7 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,3 +1,5 @@
+github.com/bwmarrin/snowflake v0.3.0 h1:xm67bEhkKh6ij1790JB83OujPR5CzNe8QuQqAgISZN0=
+github.com/bwmarrin/snowflake v0.3.0/go.mod h1:NdZxfVWX+oR6y2K0o6qAYv6gIOP9rjG0/E9WsDpxqwE=
 github.com/chromedp/cdproto v0.0.0-20230802225258-3cf4e6d46a89/go.mod h1:GKljq0VrfU4D5yc+2qA6OVr8pmO/MBbPEWqWQ/oqGEs=
 github.com/chromedp/chromedp v0.9.2/go.mod h1:LkSXJKONWTCHAfQasKFUZI+mxqS4tZqhmtGzzhLsnLs=
 github.com/chromedp/sysutil v1.0.0/go.mod h1:kgWmDdq8fTzXYcKIBqIYvRRTnYb9aNS9moAV0xufSww=


### PR DESCRIPTION
refs #1 

現在 `id_generator` テーブルを使ってDBでidを採番しているが、採番頻度が増えた影響かdeadlockが多発するようになった。
https://github.com/okashoi/isucon12-practice-20240720/issues/1#issuecomment-2241013002

アプリ側でidを採番するように変えることで、この問題の解消を図る。

https://github.com/bwmarrin/snowflake